### PR TITLE
feat: support for ETH PDU session establishment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+# Exclude common files and directories
+.git
+.idea
+.vscode
+*.log
+*.md
+LICENSE
+README*
+.gitignore
+
+# Exclude build artifacts
+main
+bin/
+vendor/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+# Use an official Go runtime as a parent image
+FROM golang:1.22-alpine AS builder
+
+# Set the working directory to /app
+WORKDIR /app
+
+# Install system packages
+RUN apk add --no-cache git
+    
+# Copy go mod and sum files
+COPY go.mod go.sum ./
+
+# Download all dependencies. Dependencies will be cached if the go.mod and go.sum files are not changed
+RUN go mod download
+
+# Install any required dependencies
+RUN go get -u -v github.com/alvaroloes/enumer && \
+    go install github.com/alvaroloes/enumer
+
+# Copy the current directory contents into the container at /app
+COPY . .
+
+# Generate Go files using `enumer` package
+RUN go generate ./pkg/pfcp
+
+# Build the executable
+RUN go build -o pfcpclient cmd/pfcpclient/main.go
+
+# Start a new stage for running the application
+FROM alpine:3.19 AS runtime
+
+WORKDIR /app
+
+# Copy the compiled binary from the builder stage
+COPY --from=builder /app/pfcpclient /app/
+
+# Expose port 8805 for the app to listen on
+EXPOSE 8805
+
+# Serve the app using CMD
+# CMD [ "/pfcpclient" ]


### PR DESCRIPTION
Added IEs to support ETH PDU session establishment.
* Added IEs for EthernetPDUSessionInformation
* Added IEs for EthernetPacketFilter
* Added IEs for MACAddress
* Added IEs for EthernetFilterProperties
* TODO (tech debt) for C-TAG and S-TAG IEs

This will enable development and testing of UPF's ETH PDU session support. The see sample session config below.

```yaml
- fars:
  - applyAction: Forward
    farID: 1
    forwardingParameters:
      destinationInterface: Core
      networkInstance: core.oai.org
  - applyAction: Forward
    farID: 2
    forwardingParameters:
      destinationInterface: Access
      networkInstance: access.oai.org
      outerHeaderCreation:
        desc: OUTER_HEADER_CREATION_GTPU_UDP_IPV4
        ip: 192.168.71.130
        teid: 1
  pdrs:
  - farID: 1
    outerHeaderRemoval: OUTER_HEADER_GTPU_UDP_IPV4
    pdi:
      localFTEID:
        ip4: 192.168.71.134
        teid: 1
      networkInstance: access.oai.org
      sourceInterface: Access
      ethernetPDUSessionInformation:
        ethI: 1
      ethernetPacketFilter:
        ethernetFilterID: 12
        ethernetFilterProperties:
          bide: 1
        macAddress:
          source: 00:00:5e:00:53:01
          destination: 00:00:5e:00:54:01
          upperSource: 00:00:5e:00:53:09
          upperDestination: 00:00:5e:00:54:09
        ethertype: 0x0800
        sdfFilter:
          flowDescription: 'permit in ip from 0.0.0.0/0 to 0.0.0.0/0'
    pdrID: 1
    precedence: 0
  - farID: 2
    pdi:
      networkInstance: core.oai.org
      sourceInterface: Core
      ueIPAddress:
        ip4: 16.0.0.1
        isDestination: true
    pdrID: 2
    precedence: 0
  seid: 0
```